### PR TITLE
Fix: stakeholders

### DIFF
--- a/src/components/molecules/Modals/StakeholderModal/StakeholderModal.module.scss
+++ b/src/components/molecules/Modals/StakeholderModal/StakeholderModal.module.scss
@@ -47,6 +47,12 @@
 
     ul {
       list-style: inside;
+
+      a {
+        &:hover {
+          text-decoration: underline;
+        }
+      }
     }
 
     p {
@@ -93,6 +99,15 @@
   }
 
   .content {
+    ul {
+      li::marker {
+        color: $hight-light-primary;
+      }
+      a {
+        color: $hight-light-primary;
+      }
+    }
+
     button {
       background-color: $hight-light-primary;
 
@@ -125,6 +140,14 @@
   }
 
   .content {
+    ul {
+      li::marker {
+        color: $tertiary;
+      }
+      a {
+        color: $tertiary;
+      }
+    }
     button {
       background-color: $tertiary;
 
@@ -157,6 +180,14 @@
   }
 
   .content {
+    ul {
+      li::marker {
+        color: $light-primary;
+      }
+      a {
+        color: $light-primary;
+      }
+    }
     button {
       background-color: $light-primary;
 
@@ -189,6 +220,14 @@
   }
 
   .content {
+    ul {
+      li::marker {
+        color: $quaternary;
+      }
+      a {
+        color: $quaternary;
+      }
+    }
     button {
       background-color: $quaternary;
 
@@ -221,6 +260,14 @@
   }
 
   .content {
+    ul {
+      li::marker {
+        color: $secondary;
+      }
+      a {
+        color: $secondary;
+      }
+    }
     button {
       background-color: $secondary;
 

--- a/src/components/molecules/Modals/StakeholderModal/StakeholderModal.tsx
+++ b/src/components/molecules/Modals/StakeholderModal/StakeholderModal.tsx
@@ -3,7 +3,7 @@ import Styles from "./StakeholderModal.module.scss";
 import { Modal } from "../../../atoms/Modals/Modal/Modal";
 import { Button } from "../../../atoms/Buttons/Button/Button";
 import { CategoriesContentStakeholder, Stakeholder } from "../../../../types";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { APP_LINKS } from "../../../../utils/appLinks";
 import { LOCAL_STORAGE_KEY } from "../../../../utils/keys/localStorageKeys";
 import React from "react";
@@ -65,16 +65,11 @@ export const StakeholderModal = ({
           <p>{stakeholder?.content.definition} :</p>
           <ul>
             {stakeholder?.content?.bbs?.map((bbs, index) => (
-              <li key={bbs.name + index}>{bbs.name}</li>
+              <li key={bbs.name + index}>
+                <Link to={bbs.path}>{bbs.name}</Link>
+              </li>
             ))}
           </ul>
-          <Button
-            onClick={() => {
-              handleClickButton();
-            }}
-          >
-            Learn more
-          </Button>
         </>
       );
     }

--- a/src/data/project/stakeholders/stakeholders.ts
+++ b/src/data/project/stakeholders/stakeholders.ts
@@ -56,7 +56,7 @@ export const STAKEHOLDER_CONTENT: ContentStakeholder[] = [
         content: {
           title: "Individuals (end users)",
           definition: "Get innovative employment and orientation services.",
-          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#7-toc-title",
+          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#12-toc-title",
           benefits: [
             {
               actor: "Monetary benefits",
@@ -196,7 +196,7 @@ export const STAKEHOLDER_CONTENT: ContentStakeholder[] = [
         content: {
           title: "University & Training Providers (data and service providers)",
           definition: "Match their offers with relevant profiles.",
-          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#7-toc-title",
+          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#12-toc-title",
           benefits: [
             {
               actor: "Monetary benefits",
@@ -337,7 +337,7 @@ export const STAKEHOLDER_CONTENT: ContentStakeholder[] = [
           title: "Employers (data providers and end users)",
           definition:
             "Match their offers with relevant profiles and get precise employee profiles. ",
-          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#7-toc-title",
+          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#12-toc-title",
           benefits: [
             {
               actor: "Monetary benefits",
@@ -478,7 +478,7 @@ export const STAKEHOLDER_CONTENT: ContentStakeholder[] = [
           title: "Educational Institutions (service providers and end users)",
           definition:
             "Provide students with innovative employment and orientation services.",
-          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#7-toc-title",
+          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#12-toc-title",
           benefits: [
             {
               actor: "Monetary benefits",
@@ -634,7 +634,7 @@ export const STAKEHOLDER_CONTENT: ContentStakeholder[] = [
         content: {
           title: "Employment Agencies (service providers and end users)",
           definition: "Offer innovative employment and orientation services.",
-          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#7-toc-title",
+          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#12-toc-title",
           benefits: [
             {
               actor: "Monetary benefits",
@@ -765,7 +765,7 @@ export const STAKEHOLDER_CONTENT: ContentStakeholder[] = [
           title: "Edtechs & AI Providers (data and service providers)",
           definition:
             "Offer better-personalised services due to better data access. ",
-          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#7-toc-title",
+          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#12-toc-title",
           benefits: [
             {
               actor: "Monetary benefits",
@@ -899,7 +899,7 @@ export const STAKEHOLDER_CONTENT: ContentStakeholder[] = [
           title: "Infrastructure Providers",
           definition:
             "Offer services and building blocks to enable data matching, including consent, contract, interoperability, data visualisation, and decentralised processing.",
-          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#7-toc-title",
+          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#12-toc-title",
           benefits: [
             {
               actor: "Monetary benefits",
@@ -997,7 +997,7 @@ export const STAKEHOLDER_CONTENT: ContentStakeholder[] = [
           title: "Orchestrator",
           definition:
             "Provides the ecosystem portal and coordinates governance, use cases, and business model discussions.",
-          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#7-toc-title",
+          wiki: "https://www.skillsdataspace.eu/blueprint/overview-of-strategic-usage-scenarios/#12-toc-title",
           benefits: [
             {
               actor: "Monetary benefits",


### PR DESCRIPTION
- link wiki inside value section of stakeholders inside MATCH usage scenario
- change li inside technical section of stakeholders to link who redirect directly in their building blocks page